### PR TITLE
Add ScottoLong to "main"

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ All of my custom keyboards, keymaps, and case files are stored here.
     -   [ScottoInvader](https://github.com/joe-scotto/keyboards/tree/main/ScottoInvader) - A 36 key column staggered ortholinear keyboard.
     -   [ScottoSplit](https://github.com/joe-scotto/keyboards/tree/main/ScottoSplit) - A 36 key column staggered split keyboard that uses VGA interconnects.
     -   [Scotto34](https://github.com/joe-scotto/keyboards/tree/main/Scotto34) - A 34 ortholinear board that uses choc switches and mounts the controller on top.
+    -   [ScottoLong](https://github.com/joe-scotto/scottokeebs/tree/main/ScottoLong) - A 33 ortholinear handwired board with a 7u spacebar.
     
 -   [other](https://github.com/joe-scotto/keyboards/tree/other) - Case files designed by me for keyboards not designed by me. Also includes keymaps.
     -   [Iris](https://github.com/joe-scotto/keyboards/tree/other/Iris) - Tenting middle layer and keymap.

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ All of my custom keyboards, keymaps, and case files are stored here.
     -   [ScottoFly](https://github.com/joe-scotto/keyboards/tree/main/ScottoFly) - A 36 key column staggered ergonomic keyboard.
     -   [ScottoInvader](https://github.com/joe-scotto/keyboards/tree/main/ScottoInvader) - A 36 key column staggered ortholinear keyboard.
     -   [ScottoSplit](https://github.com/joe-scotto/keyboards/tree/main/ScottoSplit) - A 36 key column staggered split keyboard that uses VGA interconnects.
-    -   [Scotto34](https://github.com/joe-scotto/keyboards/tree/main/Scotto34) - A 34 ortholinear board that uses choc switches and mounts the controller on top.
-    -   [ScottoLong](https://github.com/joe-scotto/scottokeebs/tree/main/ScottoLong) - A 33 ortholinear handwired board with a 7u spacebar.
+    -   [Scotto34](https://github.com/joe-scotto/keyboards/tree/main/Scotto34) - A 34 key ortholinear board that uses choc switches and mounts the controller on top.
+    -   [ScottoLong](https://github.com/joe-scotto/scottokeebs/tree/main/ScottoLong) - A 33 key ortholinear handwired board with a 7u spacebar.
     
 -   [other](https://github.com/joe-scotto/keyboards/tree/other) - Case files designed by me for keyboards not designed by me. Also includes keymaps.
     -   [Iris](https://github.com/joe-scotto/keyboards/tree/other/Iris) - Tenting middle layer and keymap.


### PR DESCRIPTION
ScottoLong was missing from the main listed so added that as well as added the word key to a couple items that had it missing. 